### PR TITLE
Don't send credentials on Firefox

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -125,7 +125,7 @@ var AlienTube = {
             case AlienTube.Browser.Firefox:
                 var xhr = new XMLHttpRequest();
                 xhr.open("GET", url, true);
-                xhr.withCredentials = true;
+                xhr.withCredentials = false;
                 xhr.onreadystatechange = function () {
                     if (xhr.readyState == 4) {
                         if (noHandle) {
@@ -161,7 +161,7 @@ var AlienTube = {
             case AlienTube.Browser.Firefox:
                 var xhr = new XMLHttpRequest();
                 xhr.open("POST", url, true);
-                xhr.withCredentials = true;
+                xhr.withCredentials = false;
                 xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
                 xhr.onreadystatechange = function () {
                     if (xhr.readyState == 4) {


### PR DESCRIPTION
Reddit doesn't send Access-Control-Allow-Credentials headers (at least not on GET requests; I'm guessing it doesn't on POST requests either), set xhr.withCredentials to false so that it doesn't error out.

Note: I'm not entirely sure whether Reddit sends it on POST requests so it's possible comments may be able to be posted; for now, this fix sets both GET and POST requests to not use credentials, but this may need changing.
