### PR TITLE
Fixes comment layout for Firefox.

### DIFF
--- a/res/style.scss
+++ b/res/style.scss
@@ -4,6 +4,10 @@ body {
     transition: background-color 1ms linear !important;
 }
 
+#watch-discussion {
+	overflow: hidden;
+}
+
 #alientube {
     font-family: -apple-system, ".SFNSDisplay-Regular", "Helvetica Neue", "Helvetica", Arial, sans-serif;
     padding-bottom: 20px;
@@ -12,6 +16,7 @@ body {
     box-sizing: border-box;
     background: #fff;
     box-shadow: 0 1px 2px rgba(0,0,0,.1);
+    overflow: hidden;
 
     & a {
         color: #0066aa;


### PR DESCRIPTION
I know you won't update for Firefox any more, but at least merge in updates for the convenience of your small Firefox user base. This fixes #161 / #162 by adding `overflow: hidden` to each comment section. Tested on Firefox 42.0 and Chrome 46.0.2490.80.