### PR TITLE
Comments load after YouTube's custom navigation

### DIFF
--- a/TypeScript/index.ts
+++ b/TypeScript/index.ts
@@ -44,4 +44,5 @@ if (document.readyState === "complete" || document.readyState === "interactive")
 } else {
     document.addEventListener("DOMContentLoaded", at_initialise, false);
 }
+// See http://youtube.github.io/spfjs/documentation/events/
 document.addEventListener("spfdone", at_initialise, false);

--- a/TypeScript/index.ts
+++ b/TypeScript/index.ts
@@ -44,3 +44,4 @@ if (document.readyState === "complete" || document.readyState === "interactive")
 } else {
     document.addEventListener("DOMContentLoaded", at_initialise, false);
 }
+document.addEventListener("spfdone", at_initialise, false);


### PR DESCRIPTION
See http://youtube.github.io/spfjs/documentation/events/.
The `spfdone` event is fired when YouTube completes an internal page load.
Fixes #194.