### PR TITLE
Fix comments not loading after YouTube's custom navigation

### DIFF
--- a/TypeScript/Application.ts
+++ b/TypeScript/Application.ts
@@ -39,7 +39,7 @@ module AlienTube {
                 }
                 
                 if (Application.currentMediaService() === Service.YouTube) {
-                    // Start observer to detect when a new video is loaded.
+                    // Add event listener to detect when a new video is loaded.
                     // See http://youtube.github.io/spfjs/documentation/events/
                     document.addEventListener("spfdone", this.youtubeEventListener);
                     

--- a/TypeScript/Application.ts
+++ b/TypeScript/Application.ts
@@ -40,9 +40,8 @@ module AlienTube {
                 
                 if (Application.currentMediaService() === Service.YouTube) {
                     // Start observer to detect when a new video is loaded.
-                    let observer = new MutationObserver(this.youtubeMutationObserver);
-                    let config = { attributes: true, childList: true, characterData: true };
-                    observer.observe(document.getElementById("content"), config);
+                    // See http://youtube.github.io/spfjs/documentation/events/
+                    document.addEventListener("spfdone", this.youtubeEventListener);
                     
                     // Start a new comment section.
                     this.currentVideoIdentifier = Application.getCurrentVideoId();
@@ -59,27 +58,22 @@ module AlienTube {
         }
 
         /**
-            * Mutation Observer for monitoring for whenver the user changes to a new "page" on YouTube
-            * @param mutations A collection of mutation records
+            * Event listener for monitoring for whenever the user changes to a new "page" on YouTube
+            * @param event YouTube's internal page load event
             * @private
         */
-        private youtubeMutationObserver(mutations: Array<MutationRecord>) {
-            mutations.forEach(function (mutation) {
-                let target = <HTMLElement>mutation.target;
-                if (target.classList.contains("yt-card") ||  target.id === "content") {
-                    let reportedVideoId = Application.getCurrentVideoId();
-                    if (reportedVideoId !== this.currentVideoIdentifier) {
-                        this.currentVideoIdentifier = reportedVideoId;
-                        if (Utilities.isVideoPage) {
-                            Application.commentSection = new CommentSection(this.currentVideoIdentifier);
-                        }
-                    }
+        private youtubeEventListener(event: Event) {
+            let reportedVideoId = Application.getCurrentVideoId();
+            if (reportedVideoId !== this.currentVideoIdentifier) {
+                this.currentVideoIdentifier = reportedVideoId;
+                if (Utilities.isVideoPage) {
+                    Application.commentSection = new CommentSection(this.currentVideoIdentifier);
                 }
-            }.bind(this));
+            }
         }
         
         /**
-            * Mutation Observer for monitoring for whenver the user changes to a new "page" on YouTube
+            * Mutation Observer for monitoring for whenever the user changes to a new "page" on YouTube
             * @param mutations A collection of mutation records
             * @private
         */


### PR DESCRIPTION
For quite some time now, navigating to a new page using YouTube's internal loading system would prevent Reddit comments from showing up until the page was actually reloaded.

This fixes the issue by hooking into YouTube's custom page load event system. Specifically, it listens for the `"spfdone"` event, which is equivalent to the native `"DOMContentLoaded"` event.
http://youtube.github.io/spfjs/documentation/events/